### PR TITLE
fix: Only consider files from 3 days ago for daily report

### DIFF
--- a/target/bin/report-pflogsumm-yesterday
+++ b/target/bin/report-pflogsumm-yesterday
@@ -14,7 +14,7 @@ SENDER=${3}
 [[ -x /usr/sbin/pflogsumm ]] || _exit_with_error "'/usr/sbin/pflogsumm' not found or executable"
 
 # shellcheck disable=SC2046
-BODY=$(gzip -cdfq $(find /var/log/mail -type f -name 'mail.log*' -mtime -180 | sort -rV) | /usr/sbin/pflogsumm --problems_first -d yesterday)
+BODY=$(gzip -cdfq $(find /var/log/mail -type f -name 'mail.log*' -mtime -3 | sort -rV) | /usr/sbin/pflogsumm --problems_first -d yesterday)
 
 sendmail -t <<EOF
 From: ${SENDER}


### PR DESCRIPTION
The modification done in #4709 would use 180 days, which is not needed.  

NOTE: this filtering is only useful for performance, to avoid processing lots of file if log retention is high. As pointed in the previous PR, the new log format in latest releases includes the year so it prevents errors in pflogumm reporting.

# Description



Fixes #4709

## Type of change

<!-- Delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change that does improve existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md or the documentation under `docs/`)
- [ ] If necessary, I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] **I have added information about changes made in this PR to `CHANGELOG.md`**
